### PR TITLE
Specify license on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
     "scripts": {
       "ms/index.js": "index.js"
     }
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Hey there,

We're using an automated tool called License Finder (https://github.com/pivotal/LicenseFinder) and your node module comes up as "Unknown". By adding the license to package.json you would help immensely users of this and other automated tools to figure out whether a module can be used inside another project.

Thanks!