### PR TITLE
Specify License in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "ms",
   "version": "0.7.1",
   "description": "Tiny ms conversion utility",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/guille/ms.js.git"


### PR DESCRIPTION
The README file specifies the MIT Licence, but the field is missing from package.json.